### PR TITLE
Various fixes to Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ Here is a demo of some of the basics.
 #### Spawning a Fiber
 
 ```clojure
-(require '[tapestry.core :refer [fiber]])
+(require '[tapestry.core :refer [fiber fiber-loop]])
 
 ;; Spawning a Fiber behaves very similarly to `future` in standard clojure, but
 ;; runs in a Loom Fiber and returns a manifold deferred.

--- a/Readme.md
+++ b/Readme.md
@@ -73,6 +73,21 @@ sudo ln -s java-16-openjdk-loom-preview $PWD/default
 sudo ln -s java-16-openjdk-loom-preview $PWD/default-runtime
 ```
 
+Alternatively, you can install a loom preview build from [sdkman](https://sdkman.io/install)
+
+```
+$ sdkman install java 17.ea.2.lm-open
+    ...
+Installing: java 17.ea.2.lm-open
+Done installing!
+
+Do you want java 17.ea.2.lm-open to be set as default? (Y/n): n
+$ sdk use java 17.ea.2.lm-open
+
+Using java version 17.ea.2.lm-open in this shell.
+```
+The sdkman maintainers update the preview build often. To find the most up to date version look for the java identifier containing "lm".
+
 ## Showcase
 
 Full API documentation can be seen in the `tapestry.core` ns itself. Right now we can't build

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ Here is a demo of some of the basics.
 #### Spawning a Fiber
 
 ```clojure
-(require [tapestry.core :refer [fiber]])
+(require '[tapestry.core :refer [fiber]])
 
 ;; Spawning a Fiber behaves very similarly to `future` in standard clojure, but
 ;; runs in a Loom Fiber and returns a manifold deferred.
@@ -103,7 +103,8 @@ Here is a demo of some of the basics.
 
 #### Processing Sequences
 ```clojure
-(require [tapestry.core :refer [parallely asyncly pfor]])
+(require '[tapestry.core :refer [parallelly asyncly pfor]]
+         '[clj-http.client :as clj-http])
 
 (def urls
   ["https://google.com"
@@ -130,7 +131,7 @@ Here is a demo of some of the basics.
 
 ```clojure
 ;; We can control max parallelism for fibers
-(require [tapestry.core :refer [parallely]])
+(require '[tapestry.core :refer [parallelly]])
 
 ;; Note that you can also use `with-max-parallelism` within a fiber body
 ;; which will limit parallelism of all newly spawned fibers. Consider the following
@@ -161,16 +162,16 @@ Here is a demo of some of the basics.
 
 (asyncly 3 clj-http/get urls)
 
-(parallely 3 clj-http/get urls)
+(parallelly 3 clj-http/get urls)
 ```
 
 
 #### Manifold Support
 
 ```clojure
-(require [manifold.stream :as s]
-         [tick.api.alpha :as t]
-         [tapestry.core :refer [periodically parallely asyncly]])
+(require '[manifold.stream :as s]
+         '[tick.alpha.api :as t]
+         '[tapestry.core :refer [periodically parallelly asyncly]])
 
 ;; tapestry.core/periodically behaves very similar to manfold's built in periodically,
 ;; but runs each task in a fiber. You can terminate it by closing the stream.
@@ -181,7 +182,7 @@ Here is a demo of some of the basics.
     (Thread/sleep 5000)
     (s/close! generator))
 
-;; Also, `parallely` and `asyncly` both suppport manifold streams, allowing you to describe parallel
+;; Also, `parallelly` and `asyncly` both suppport manifold streams, allowing you to describe parallel
 ;; execution pipelines
 (->> (s/stream)
      (paralelly 5 some-operation)


### PR DESCRIPTION
Found a number of issues with the example code in Readme.md as I was experimenting with tapestry in the repl. 

fixed: 
- all references to "parallely" were changed to "parallelly"
- added reference to fiber-loop in require expression
- added reference to clj-http in require expression
- "tick.api.alpha" was corrected to "tick.alpha.api"
