### PR TITLE
Readme fixes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,7 +103,7 @@ Here is a demo of some of the basics.
 
 #### Processing Sequences
 ```clojure
-(require [tapestry.core :refer [parallely asyncly pfor]])
+(require [tapestry.core :refer [parallelly asyncly pfor]])
 
 (def urls
   ["https://google.com"
@@ -130,7 +130,7 @@ Here is a demo of some of the basics.
 
 ```clojure
 ;; We can control max parallelism for fibers
-(require [tapestry.core :refer [parallely]])
+(require [tapestry.core :refer [parallelly]])
 
 ;; Note that you can also use `with-max-parallelism` within a fiber body
 ;; which will limit parallelism of all newly spawned fibers. Consider the following
@@ -161,7 +161,7 @@ Here is a demo of some of the basics.
 
 (asyncly 3 clj-http/get urls)
 
-(parallely 3 clj-http/get urls)
+(parallelly 3 clj-http/get urls)
 ```
 
 
@@ -170,7 +170,7 @@ Here is a demo of some of the basics.
 ```clojure
 (require [manifold.stream :as s]
          [tick.api.alpha :as t]
-         [tapestry.core :refer [periodically parallely asyncly]])
+         [tapestry.core :refer [periodically parallelly asyncly]])
 
 ;; tapestry.core/periodically behaves very similar to manfold's built in periodically,
 ;; but runs each task in a fiber. You can terminate it by closing the stream.
@@ -181,7 +181,7 @@ Here is a demo of some of the basics.
     (Thread/sleep 5000)
     (s/close! generator))
 
-;; Also, `parallely` and `asyncly` both suppport manifold streams, allowing you to describe parallel
+;; Also, `parallelly` and `asyncly` both suppport manifold streams, allowing you to describe parallel
 ;; execution pipelines
 (->> (s/stream)
      (paralelly 5 some-operation)

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ Here is a demo of some of the basics.
 #### Spawning a Fiber
 
 ```clojure
-(require [tapestry.core :refer [fiber]])
+(require '[tapestry.core :refer [fiber fiber-loop]])
 
 ;; Spawning a Fiber behaves very similarly to `future` in standard clojure, but
 ;; runs in a Loom Fiber and returns a manifold deferred.
@@ -103,7 +103,8 @@ Here is a demo of some of the basics.
 
 #### Processing Sequences
 ```clojure
-(require [tapestry.core :refer [parallelly asyncly pfor]])
+(require '[tapestry.core :refer [parallelly asyncly pfor]]
+         '[clj-http.client :as clj-http])
 
 (def urls
   ["https://google.com"
@@ -130,7 +131,7 @@ Here is a demo of some of the basics.
 
 ```clojure
 ;; We can control max parallelism for fibers
-(require [tapestry.core :refer [parallelly]])
+(require '[tapestry.core :refer [parallelly fiber]])
 
 ;; Note that you can also use `with-max-parallelism` within a fiber body
 ;; which will limit parallelism of all newly spawned fibers. Consider the following
@@ -168,9 +169,9 @@ Here is a demo of some of the basics.
 #### Manifold Support
 
 ```clojure
-(require [manifold.stream :as s]
-         [tick.api.alpha :as t]
-         [tapestry.core :refer [periodically parallelly asyncly]])
+(require '[manifold.stream :as s]
+         '[tick.alpha.api :as t]
+         '[tapestry.core :refer [periodically parallelly asyncly]])
 
 ;; tapestry.core/periodically behaves very similar to manfold's built in periodically,
 ;; but runs each task in a fiber. You can terminate it by closing the stream.


### PR DESCRIPTION
Updates to the readme examples for a smoother repl experience:

- Replaced references to "parallely" with "parallelly"
- quoted all the vectors in require forms
- added "fiber-loop" to referred symbols in the first example
- added clj-http.client to require form under "Processing Sequences"
- added fiber to referred symbols under "Bounded Parallelism"
- corrected required tick namespace "tick.api.alpha" to "tick.alpha.api"

Thank you! Had fun playing experimenting with this lib. Looking forward to tapestry/loom full release!