### PR TITLE
Manifold has moved to clj-commons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tmp/
 .nrepl-port
 pom.xml
 target/
+.lsp/
 .clj-kondo/.cache/

--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,7 @@ Fibers behave similarly to OS level threads, but are much lighter weight to spaw
 potentially millions of them to exist.
 
 Clojure already has the wonderful [core.async](https://github.com/clojure/core.async)
-and [manifold](https://github.com/aleph-io/manifold) libraries but writing maximally performant code
+and [manifold](https://github.com/clj-commons/manifold) libraries but writing maximally performant code
 in either requires the abstraction (channels, or promises) to leak all over your code
 (as you return channels or promise chains) to avoid blocking. Furthermore you frequently have to
 think about which executor will handle the blocking code.

--- a/deps.edn
+++ b/deps.edn
@@ -11,7 +11,7 @@
    :jvm-opts    ["--enable-preview"]
    :main-opts   ["-m" "kaocha.runner"]
    :extra-deps
-   {org.clojure/test.check {:mvn/version "0.10.0"}
-    lambdaisland/kaocha    {:mvn/version "0.0-541"}}}}
+   {org.clojure/test.check {:mvn/version "1.1.1"}
+    lambdaisland/kaocha    {:mvn/version "1.87.1366"}}}}
  :deps
- {manifold/manifold {:mvn/version "0.1.9-alpha3"}}}
+ {manifold/manifold {:mvn/version "0.4.2"}}}


### PR DESCRIPTION
Noticed that the link to manifold still points to the archived/moved repository instead of clj-commons, so I've updated the link and updated the manifold-dependency (and test-deps).

As I develop using Calva I also added the .lsp-folder to .gitignore.